### PR TITLE
Totp

### DIFF
--- a/openconnect_sso/browser/browser.py
+++ b/openconnect_sso/browser/browser.py
@@ -69,11 +69,9 @@ class Browser:
     def authenticate_at(self, url, expected_cookie_name, override_script):
         try:
             script = self.get_script(self.cfg.credentials, override_script)
-            self.driver.execute_script(script)
             self.driver.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", script)
             self.driver.get(url)
             if self.cfg.credentials:
-                script = self.get_script(self.cfg.credentials, override_script)
                 # self.driver.execute_script(script)
                 return WebDriverWait(self.driver, self.cfg.authenticate_timeout).until(
                     lambda driver: get_cookie(

--- a/openconnect_sso/browser/browser.py
+++ b/openconnect_sso/browser/browser.py
@@ -69,10 +69,11 @@ class Browser:
     def authenticate_at(self, url, expected_cookie_name, override_script):
         try:
             script = self.get_script(self.cfg.credentials, override_script)
-            self.driver.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", script)
+            self.driver.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", {
+                "source": script
+            })
             self.driver.get(url)
             if self.cfg.credentials:
-                # self.driver.execute_script(script)
                 return WebDriverWait(self.driver, self.cfg.authenticate_timeout).until(
                     lambda driver: get_cookie(
                         self.driver.get_cookies(), expected_cookie_name


### PR DESCRIPTION
Use Chrome Devtools Protocol to execute the override script on all page loads to allow TOTP SSO to work correctly.